### PR TITLE
Filtering by JNN also shows MJNN results

### DIFF
--- a/chars/src/Utils/filter.js
+++ b/chars/src/Utils/filter.js
@@ -7,11 +7,13 @@ function filterSelection(c) {
 
     var x, i;
     x = document.getElementsByClassName("filterDiv");
-    if (c == "all") c = "";
     // Add the "show" class (display:block) to the filtered elements, and remove the "show" class from the elements that are not selected
     for (i = 0; i < x.length; i++) {
         w3RemoveClass(x[i], "show");
-        if (x[i].className.indexOf(c) > -1) w3AddClass(x[i], "show");
+        // wrap class names in spaces to prevent matching prefixes or suffixes
+        if (c === "all" || (' ' + x[i].className + ' ').indexOf(' ' + c + ' ') > -1) {
+            w3AddClass(x[i], "show");
+        }
     }
 }
 


### PR DESCRIPTION
How to reproduce:
1. Go to any nesoberi with both JNN and MJNN (e.g. https://nesodb.me/chars/?char=chika)
2. Filter by JNN
3. Both JNN and MJNN nesos are shown

This occurs because msizes are being checked with indexOf. By wrapping it with spaces, we can prevent matching prefixes/suffixes.